### PR TITLE
Update exporter and telegraf; fix release workflow

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -1,11 +1,16 @@
+name: Docker Build
 
 on:
-  push:
-    tags:
-      - 'v*.*.*'
+  release:
+    types:
+    - created
+  pull_request:
+    types:
+    - opened
+    - synchronize
 
 jobs:
-  release:
+  docker_build:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -25,15 +30,21 @@ jobs:
       - name: Set output
         id: vars
         run: |
-          TAG_NAME=${{ github.ref_name }}
-          echo ::set-output name=version::${TAG_NAME#v/}
+          EVENT_NAME=${{ github.event_name }}
+          if [[ "${EVENT_NAME}" == "release" ]]; then
+            REF_NAME=${{ github.ref_name }}
+          else
+            REF_NAME="pull_request"
+          fi
+          echo ::set-output name=version::${REF_NAME#v/}
 
       - name: Build and push
         uses: docker/build-push-action@v2
         with:
           context: .
           file: ./Dockerfile
-          push: true
+          # only push if we are being triggered by a release
+          push: ${{ github.event_name == 'release' }}
           tags: ${{ secrets.DOCKER_HUB_USERNAME }}/pgpool-cloudsql:${{ steps.vars.outputs.version }}
           cache-from: type=registry,ref=${{ secrets.DOCKER_HUB_USERNAME }}/pgpool-cloudsql:buildcache
           cache-to: type=registry,ref=${{ secrets.DOCKER_HUB_USERNAME }}/pgpool-cloudsql:buildcache,mode=max

--- a/bin/exporter.sh
+++ b/bin/exporter.sh
@@ -56,9 +56,8 @@ until echo 'SELECT null;' | psql -h "${PGPOOL_SERVICE}" -p "${PGPOOL_SERVICE_POR
   sleep 5
 done
 
-# for some reason, pgpool2_exporter's log level filtering is very broken
 set -o pipefail
-/bin/pgpool2_exporter --log.level=info --log.format=logfmt 2>&1 | grep -v 'level=debug'
+/bin/pgpool2_exporter --log.level=info --log.format=logfmt 2>&1
 EVAL="$?"
 log error "pgpool2_exporter exited with value ${EVAL}"
 sleep 1 # don't spam the kubelet

--- a/charts/pgpool-cloudsql/Chart.yaml
+++ b/charts/pgpool-cloudsql/Chart.yaml
@@ -15,7 +15,7 @@ apiVersion: v2
 description: the pgpool-ii connection pooling postgres proxy with automatic discovery of GCP CloudSQL backends
 name: pgpool-cloudsql
 type: application
-version: 1.0.5
+version: 1.0.6
 keywords:
 - postgresql
 - pgpool

--- a/charts/pgpool-cloudsql/templates/service.yaml
+++ b/charts/pgpool-cloudsql/templates/service.yaml
@@ -5,6 +5,10 @@ metadata:
   name: "{{ .Release.Name }}"
   labels:
     app: "{{ .Release.Name }}"
+    tier: "{{ .Values.deploy.service.tier }}"
+    {{- with .Values.deploy.service.additionalLabels }}
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
 spec:
   ports:
   - port: 5432

--- a/charts/pgpool-cloudsql/values.yaml
+++ b/charts/pgpool-cloudsql/values.yaml
@@ -15,7 +15,7 @@
 deploy:
   replicaCount: 1
   repository: odentech/pgpool-cloudsql
-  tag: 1.0.5
+  tag: 1.0.6
   affinity: {}
     # # pin tasks to the default node pool
     # nodeAffinity:
@@ -50,6 +50,9 @@ deploy:
     telegraf: {}
   podDisruptionBudget:
     maxUnavailable: 1
+  service:
+    tier: "db"
+    additionalLabels: {}
 
 discovery:
   # Because Google CloudSQL does not allow for immediate reuse of DB instance names,


### PR DESCRIPTION
- update `pgpool2_exporter` to the v1.2.0 release; this includes
  all of our fixes and means we no longer need to build a local version

- update the exporter wrapper script; v1.2.0 includes fixes for
  the logging issues we were seeing

- update `telegraf` to v1.22.0; this includes all of our fixes
  for stackdriver cumulative metric exports

- add a default 'tier' label to the pgpool k8s service

- add a helm value to support adding arbitrary labels to the pgpool k8s service

- fix the docker workflow so it fires correctly when a new
  release is published