### PR TITLE
1.0.10: fix log spew

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN go install ./cmd/envtpl/...
 FROM --platform=linux/amd64 alpine:${ALPINE_VERSION}
 RUN apk add --no-cache curl python3
 
-ARG TELEGRAF_VERSION=1.22.0
+ARG TELEGRAF_VERSION=1.24.2
 RUN curl -sfL https://dl.influxdata.com/telegraf/releases/telegraf-${TELEGRAF_VERSION}_static_linux_amd64.tar.gz |\
   tar zxf - --strip-components=2 -C /
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ helm repo update
 ```sh
 export RELEASE_NAME=my-pgpool-service # a name (you will need 1 installed chart for each primary DB)
 export NAMESPACE=my-k8s-namespace     # a kubernetes namespace
-export CHART_VERSION=1.0.9            # a chart version: https://github.com/odenio/pgpool-cloudsql/releases
+export CHART_VERSION=1.0.10           # a chart version: https://github.com/odenio/pgpool-cloudsql/releases
 export VALUES_FILE=./my_values.yaml   # your values file
 
 helm install \
@@ -100,8 +100,8 @@ Parameter | Description | Default
 --- | --- | ---
 `deploy.replicaCount` | Number of pod replicas to deploy | `1`
 `deploy.repository` | Docker image repository of the runtime image | `odentech/pgpool-cloudsql`
-`deploy.tag` | Docker image tag of the runtime image | `1.0.9`
-`deploy.service.tier` | Value for the "tier" [label](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/) applied to the kubernetes [service](https://kubernetes.io/docs/concepts/services-networking/service/) | `1.0.9`
+`deploy.tag` | Docker image tag of the runtime image | `1.0.10`
+`deploy.service.tier` | Value for the "tier" [label](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/) applied to the kubernetes [service](https://kubernetes.io/docs/concepts/services-networking/service/) | `db`
 `deploy.service.additionalLabels` | Map of additional k/v string pairs to add as labels for the kubernetes service | `{}`
 `deploy.affinity` | Kubernetes [affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/) spec applied to the deployment pods | `{}`
 `deploy.tolerations` | Kubernetes [tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) spec applied to the deployment pods | `{}`

--- a/charts/pgpool-cloudsql/Chart.yaml
+++ b/charts/pgpool-cloudsql/Chart.yaml
@@ -15,7 +15,7 @@ apiVersion: v2
 description: the pgpool-ii connection pooling postgres proxy with automatic discovery of GCP CloudSQL backends
 name: pgpool-cloudsql
 type: application
-version: 1.0.9
+version: 1.0.10
 keywords:
 - postgresql
 - pgpool

--- a/charts/pgpool-cloudsql/templates/configmap.yaml
+++ b/charts/pgpool-cloudsql/templates/configmap.yaml
@@ -34,3 +34,11 @@ data:
     # Read metrics from the pgpool2_exporter container
     [[inputs.prometheus]]
         urls = ["http://localhost:9719/metrics"]
+
+    # alas until and unless the stackdriver output plugin gains
+    # the ability to handle histogram/distribution metrics, it is
+    # not safe to enable this: our logs become an endless stream
+    # of errors about the `go_gc_duration_seconds` metric having
+    # an unsupported ValueType
+    [[inputs.internal]]
+      collect_memstats = false

--- a/charts/pgpool-cloudsql/values.yaml
+++ b/charts/pgpool-cloudsql/values.yaml
@@ -15,7 +15,7 @@
 deploy:
   replicaCount: 1
   repository: odentech/pgpool-cloudsql
-  tag: 1.0.9
+  tag: 1.0.10
   affinity: {}
     # # pin tasks to the default node pool
     # nodeAffinity:


### PR DESCRIPTION
- disable internal memstats collection: this produces an unending spew of errors when using the stackdriver output plugin, which does not yet support distribution/histogram metrics

- update to the latest version of telegraf (1.24.4)

This addresses https://github.com/odenio/pgpool-cloudsql/issues/6