### PR TITLE
v1.1: change failure handling for exporter/telegraf

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,8 +27,8 @@ RUN go install ./cmd/envtpl/...
 FROM --platform=linux/amd64 alpine:${ALPINE_VERSION}
 RUN apk add --no-cache curl python3
 
-ARG TELEGRAF_VERSION=1.24.2
-RUN curl -sfL https://dl.influxdata.com/telegraf/releases/telegraf-${TELEGRAF_VERSION}_static_linux_amd64.tar.gz |\
+ARG TELEGRAF_VERSION=1.26.2
+RUN curl -sfL https://dl.influxdata.com/telegraf/releases/telegraf-${TELEGRAF_VERSION}_linux_amd64.tar.gz |\
   tar zxf - --strip-components=2 -C /
 
 ARG EXPORTER_VERSION=1.2.0

--- a/README.md
+++ b/README.md
@@ -44,6 +44,12 @@ The exception is that any statement containing the string `DO NOT LOAD BALANCE`
 instance no matter what.  This is configureable at deploy time as
 `.pgpool.primaryRoutingQueryPatternList` in [values.yaml](Helm/values.yaml).
 
+## Upgrade Guides
+
+Old Version | New Version | Upgrade Guide
+--- | --- | ---
+v1.0.X | v1.1.0 | [link](UPGRADE.md#v10x--v110)
+
 # Installing the Chart
 
 ## Step One: add our Helm repository to your client:
@@ -58,7 +64,7 @@ helm repo update
 ```sh
 export RELEASE_NAME=my-pgpool-service # a name (you will need 1 installed chart for each primary DB)
 export NAMESPACE=my-k8s-namespace     # a kubernetes namespace
-export CHART_VERSION=1.0.12           # a chart version: https://github.com/odenio/pgpool-cloudsql/releases
+export CHART_VERSION=1.1.0           # a chart version: https://github.com/odenio/pgpool-cloudsql/releases
 export VALUES_FILE=./my_values.yaml   # your values file
 
 helm install \
@@ -100,7 +106,7 @@ Parameter | Description | Default
 --- | --- | ---
 `deploy.replicaCount` | Number of pod replicas to deploy | `1`
 `deploy.repository` | Docker image repository of the runtime image | `odentech/pgpool-cloudsql`
-`deploy.tag` | Docker image tag of the runtime image | `1.0.12`
+`deploy.tag` | Docker image tag of the runtime image | `1.1.0`
 `deploy.service.tier` | Value for the "tier" [label](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/) applied to the kubernetes [service](https://kubernetes.io/docs/concepts/services-networking/service/) | `db`
 `deploy.service.additionalLabels` | Map of additional k/v string pairs to add as labels for the kubernetes service | `{}`
 `deploy.affinity` | Kubernetes [affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/) spec applied to the deployment pods | `{}`
@@ -148,6 +154,20 @@ Parameter | Description | Default
 `exporter.postgresUsername` | *REQUIRED* Username used by [pgpool2_exporter](https://github.com/pgpool/pgpool2_exporter) to connect to pgpool with.  This must be a valid postgres username in your installation. | `""`
 `exporter.postgresPassword` | *REQUIRED* Password used with `exporter.postgresUsername` | `""`
 `exporter.postgresDatabase` | Postgres database used in the connection string by `pgpool2_exporter` -- this must be a valid database name in your Postgres installation. | `postgres`
+`exporter.exitOnError` | Exit the container if the exporter process exits | `false`
+
+<hr>
+</details>
+
+## telegraf options
+
+<details>
+<summary>Show More</summary>
+<hr>
+
+Parameter | Description | Default
+--- | --- | ---
+`telegraf.exitOnError` | Exit the container if the telegraf process exits | `false`
 
 <hr>
 </details>

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,0 +1,13 @@
+# Upgrading Steps
+
+## `v1.0.X` → `v1.1.0`
+
+> 🛑 this release changes the default error handling behavior for the metrics/monitoring containers; you will need to update your values.yaml if you wish to preserve the previous behavior.
+
+### Feature highlights
+
+* Added the ability to control pod restart behavior if either of the monitoring containers ([pgpool2\_exporter](https://github.com/pgpool/pgpool2_exporter) and [telegraf](https://github.com/influxdata/telegraf) restart -- depending on your workload, it may not be helpful to interrupt in-flight db transactions due to errors that are outside the critical path
+
+### VALUES - New:
+- `exporter.exitOnError` -- Exit the container if the exporter process exits (otherwise, restart the exporter after a 1s delay); default is false
+- `telegraf.exitOnError` -- Exit the container if the telegraf process exits (otherwise, restart telegraf after a 1s delay); default is false

--- a/charts/pgpool-cloudsql/Chart.yaml
+++ b/charts/pgpool-cloudsql/Chart.yaml
@@ -15,7 +15,7 @@ apiVersion: v2
 description: the pgpool-ii connection pooling postgres proxy with automatic discovery of GCP CloudSQL backends
 name: pgpool-cloudsql
 type: application
-version: 1.0.12
+version: 1.1.0
 keywords:
 - postgresql
 - pgpool

--- a/charts/pgpool-cloudsql/templates/deployment.yaml
+++ b/charts/pgpool-cloudsql/templates/deployment.yaml
@@ -165,6 +165,8 @@ spec:
           value: localhost
         - name: PGPOOL_SERVICE_PORT
           value: "5432"
+        - name: EXIT_ON_ERROR
+          value: {{ .Values.exporter.exitOnError | default "false" | quote }}
 
       - name: telegraf
         image: "{{ .Values.deploy.repository }}:{{ .Values.deploy.tag }}"
@@ -174,6 +176,9 @@ spec:
         {{- end }}
         command:
           - /usr/bin/telegraf.sh
+        env:
+        - name: EXIT_ON_ERROR
+          value: {{ .Values.telegraf.exitOnError | default "false" | quote }}
         volumeMounts:
         - name: telegraf-config
           mountPath: /etc/telegraf

--- a/charts/pgpool-cloudsql/values.yaml
+++ b/charts/pgpool-cloudsql/values.yaml
@@ -15,7 +15,7 @@
 deploy:
   replicaCount: 1
   repository: odentech/pgpool-cloudsql
-  tag: 1.0.12
+  tag: 1.1.0
   affinity: {}
     # # pin tasks to the default node pool
     # nodeAffinity:
@@ -71,6 +71,10 @@ exporter:
   postgresUsername: ""  # REQUIRED!
   postgresPassword: ""  # REQUIRED!
   postgresDatabase: "postgres"
+  exitOnError: "false"
+
+telegraf:
+  exitOnError: "false"
 
 pcp:
   password: ""


### PR DESCRIPTION
This release substantially changes the behavior of the exporter and telegraf containers in the pod: previously, a failure in either of these processes would lead to the container failing and being restarted by the kubelet, potentially leading to the entire pod being marked as unavailable.  Now by default an error is logged and the process is restarted by the wrapper script, but the container does not exit.

An `exitOnError` helm option has been added to both the `exporter` and `telegraf` config value sections: set each to "true" to restore the old behavior.