### PR TITLE
fix(discovery): fixing region initial value

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ instance no matter what.  This is configureable at deploy time as
 
 Old Version | New Version | Upgrade Guide
 --- | --- | ---
+v1.1.1 | v1.1.2 | [link](UPGRADE.md#v111--v112)
 v1.1.0 | v1.1.1 | [link](UPGRADE.md#v110--v111)
 v1.0.X | v1.1.0 | [link](UPGRADE.md#v10x--v110)
 
@@ -65,7 +66,7 @@ helm repo update
 ```sh
 export RELEASE_NAME=my-pgpool-service # a name (you will need 1 installed chart for each primary DB)
 export NAMESPACE=my-k8s-namespace     # a kubernetes namespace
-export CHART_VERSION=1.1.1           # a chart version: https://github.com/odenio/pgpool-cloudsql/releases
+export CHART_VERSION=1.1.2           # a chart version: https://github.com/odenio/pgpool-cloudsql/releases
 export VALUES_FILE=./my_values.yaml   # your values file
 
 helm install \

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,4 +1,8 @@
 # Upgrading Steps
+## `v1.1.1` → `v1.1.2`
+
+> ℹ️ this release fixes the initial value of the database region during the discovery phase.
+
 
 ## `v1.1.0` → `v1.1.1`
 

--- a/bin/discovery.sh
+++ b/bin/discovery.sh
@@ -33,11 +33,11 @@ if [ -z "${PRIMARY_INSTANCE_PREFIX}" ]; then
   log fatal "PRIMARY_INSTANCE_PREFIX unset"
 fi
 
+get_metadata
+
 if [ "${STAY_IN_REGION}" = "false" ]; then
   REGION='*'
 fi
-
-get_metadata
 
 # set up passwordless pcp auth
 if [ -z "${PCP_PASSWORD}" ]; then

--- a/charts/pgpool-cloudsql/Chart.yaml
+++ b/charts/pgpool-cloudsql/Chart.yaml
@@ -15,7 +15,7 @@ apiVersion: v2
 description: the pgpool-ii connection pooling postgres proxy with automatic discovery of GCP CloudSQL backends
 name: pgpool-cloudsql
 type: application
-version: 1.1.1
+version: 1.1.2
 keywords:
 - postgresql
 - pgpool


### PR DESCRIPTION
hi @n-oden,
i've found a little bug in the precedent version , the `get_metadata` function of https://github.com/odenio/pgpool-cloudsql/blob/47cc31fe44bb1dd56f58e93c6b304bd446c52079/bin/discovery.sh#L40 rewrites the `REGION` value .

This PR fixes the value of the variable `REGION` when `STAY_IN_REGION = false`, swapping the order.