### PR TITLE
feat(helm): exporting primary and replicas weights

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *secret*.yaml
 *.gz
 *.tgz
+.vscode

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ instance no matter what.  This is configureable at deploy time as
 
 Old Version | New Version | Upgrade Guide
 --- | --- | ---
+v1.1.3 | v1.1.4 | [link](UPGRADE.md#v113--v114)
 v1.1.2 | v1.1.3 | [link](UPGRADE.md#v112--v113)
 v1.1.1 | v1.1.2 | [link](UPGRADE.md#v111--v112)
 v1.1.0 | v1.1.1 | [link](UPGRADE.md#v110--v111)
@@ -67,7 +68,7 @@ helm repo update
 ```sh
 export RELEASE_NAME=my-pgpool-service # a name (you will need 1 installed chart for each primary DB)
 export NAMESPACE=my-k8s-namespace     # a kubernetes namespace
-export CHART_VERSION=1.1.3           # a chart version: https://github.com/odenio/pgpool-cloudsql/releases
+export CHART_VERSION=1.1.4           # a chart version: https://github.com/odenio/pgpool-cloudsql/releases
 export VALUES_FILE=./my_values.yaml   # your values file
 
 helm install \

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,4 +1,12 @@
 # Upgrading Steps
+## `v1.1.3` → `v1.1.4`
+
+> ℹ️ : this release allows to set primary and replicas weights.
+
+### VALUES - New:
+- `pgpool.primaryWeight` -- It specifies the load balancing ratio of the primary postgres instance; default is 0
+- `pgpool.replicasWeight` -- It specifies the load balancing ratio of the replicas; default is 1
+
 ## `v1.1.2` → `v1.1.3`
 
 > ℹ️ overall upgrade:

--- a/charts/pgpool-cloudsql/Chart.yaml
+++ b/charts/pgpool-cloudsql/Chart.yaml
@@ -15,7 +15,7 @@ apiVersion: v2
 description: the pgpool-ii connection pooling postgres proxy with automatic discovery of GCP CloudSQL backends
 name: pgpool-cloudsql
 type: application
-version: 1.1.3
+version: 1.1.4
 keywords:
 - postgresql
 - pgpool

--- a/charts/pgpool-cloudsql/templates/deployment.yaml
+++ b/charts/pgpool-cloudsql/templates/deployment.yaml
@@ -109,6 +109,10 @@ spec:
           value: "{{ .Values.pgpool.disableLoadBalanceOnWrite }}"
         - name: STATEMENT_LEVEL_LOAD_BALANCE
           value: "{{ .Values.pgpool.statementLevelLoadBalance }}"
+        - name: PRIMARY_WEIGHT
+          value: "{{ .Values.pgpool.primaryWeight }}"
+        - name: REPLICAS_WEIGHT
+          value: "{{ .Values.pgpool.replicasWeight }}"
         - name: LOG_MIN_MESSAGES
           value: "{{ .Values.pgpool.logMinMessages }}"
         - name: LOG_ERROR_VERBOSITY

--- a/charts/pgpool-cloudsql/values.yaml
+++ b/charts/pgpool-cloudsql/values.yaml
@@ -15,7 +15,7 @@
 deploy:
   replicaCount: 1
   repository: odentech/pgpool-cloudsql
-  tag: 1.1.3
+  tag: 1.1.4
   affinity: {}
     # # pin tasks to the default node pool
     # nodeAffinity:
@@ -144,6 +144,14 @@ pgpool:
   disableLoadBalanceOnWrite: "transaction"
   # Enables statement level load balancing
   statementLevelLoadBalance: "on"
+  # It specifies the load balancing ratio of the primary postgres instance.
+  # It can be set to any integer or floating-point value greater than or equal to zero.
+  primaryWeight: 0
+  # It specifies the load balancing ratio of the replicas.
+  # It can be set to any integer or floating-point value greater than or equal to zero.
+  # It represents the cumulative weight of the replicas,
+  # where the weight of each individual replica is divided by the total number of replicas.
+  replicasWeight: 1
   # Controls which minimum message levels are emitted to log. Valid
   # values are DEBUG5, DEBUG4, DEBUG3, DEBUG2, DEBUG1, INFO, NOTICE,
   # WARNING, ERROR, LOG, FATAL, and PANIC. Each level includes all the

--- a/conf/pgpool.conf.tmpl
+++ b/conf/pgpool.conf.tmpl
@@ -44,7 +44,7 @@ reserved_connections = {{ .RESERVED_CONNECTIONS }}
 backend_hostname0 = '{{.primary_ip}}'
 backend_port0 = 5432
 # pgpool will send all mutations to the primary; everything else should go to a replica
-backend_weight0 = 0
+backend_weight0 = {{ .PRIMARY_WEIGHT }}
 backend_flag0 = 'ALWAYS_PRIMARY|DISALLOW_TO_FAILOVER'
 backend_data_directory0 = /data0
 backend_application_name0 = 'server0'
@@ -69,7 +69,7 @@ backend_application_name0 = 'server0'
 # replica {{ $node_id }}
 backend_hostname{{ $node_id }} = '{{ $value }}'
 backend_port{{ $node_id }} = 5432
-backend_weight{{ $node_id }} = {{ divf 1.0 $num_replicas }}
+backend_weight{{ $node_id }} = {{ divf $.REPLICAS_WEIGHT $num_replicas }}
 backend_flag{{ $node_id }} = 'ALLOW_TO_FAILOVER'
 
 {{ end -}}


### PR DESCRIPTION
issue: https://github.com/odenio/pgpool-cloudsql/issues/12

### VALUES - New:
- `pgpool.primaryWeight` -- It specifies the load balancing ratio of the primary postgres instance; default is 0
- `pgpool.replicasWeight` -- It specifies the load balancing ratio of the replicas; default is 1