### PR TITLE
1.2.0: support multiple pgpool versions

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -2,52 +2,42 @@ name: Docker Build
 
 on:
   release:
-    types:
-    - created
-    - published
-    - edited
-    - released
-  pull_request:
-    types:
-    - opened
-    - synchronize
+    types: [published]
 
 jobs:
   docker_build:
+    strategy:
+      matrix:
+        pgpool_version:
+          - 4.5.0
+          - 4.4.5
+          - 4.3.8
+          - 4.2.15
+          - 4.1.18
+          - 4.0.25
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-
       - name: Set output
         id: vars
         run: |
-          EVENT_NAME=${{ github.event_name }}
-          if [[ "${EVENT_NAME}" == "release" ]]; then
-            REF_NAME=${{ github.ref_name }}
-          else
-            REF_NAME="pull_request"
-          fi
-          echo "version=${REF_NAME#v/}" >> $GITHUB_OUTPUT
+          REF_NAME=${{ github.ref_name }}
+          echo "release_version=${REF_NAME#v}" >> $GITHUB_OUTPUT
 
       - name: Build and push
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v5
         with:
-          context: .
+          context: "{{defaultContext}}"
           file: ./Dockerfile
-          # only push if we are being triggered by a release
-          push: ${{ github.event_name == 'release' }}
-          tags: ${{ secrets.DOCKER_HUB_USERNAME }}/pgpool-cloudsql:${{ steps.vars.outputs.version }}
-          cache-from: type=registry,ref=${{ secrets.DOCKER_HUB_USERNAME }}/pgpool-cloudsql:buildcache
-          cache-to: type=registry,ref=${{ secrets.DOCKER_HUB_USERNAME }}/pgpool-cloudsql:buildcache,mode=max
+          build-args: PGPOOL_VERSION=${{matrix.pgpool_version}}
+          pull: true
+          push: true
+          tags: ${{ secrets.DOCKER_HUB_USERNAME }}/pgpool-cloudsql:${{ steps.vars.outputs.release_version }}-${{matrix.pgpool_version}}

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,50 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG ALPINE_VERSION=edge
+ARG ALPINE_VERSION=3.19
+###
+### Build PGPool-II from source in a build container
+###
+FROM --platform=linux/amd64 alpine:${ALPINE_VERSION} as pgpool_build
+RUN apk update
+RUN apk add build-base libpq-dev linux-headers openssl-dev>3
+ENV pkgname pgpool
+ENV _pkgname pgpool-II
 
+ARG PGPOOL_VERSION=4.5.0
+ENV PGPOOL_VERSION ${PGPOOL_VERSION}
+
+ARG APPLY_PATCHES=false
+ENV APPLY_PATCHES ${APPLY_PATCHES}
+
+WORKDIR /usr/local/src
+
+ADD https://www.pgpool.net/download.php?f=$_pkgname-$PGPOOL_VERSION.tar.gz pgpool.tgz
+
+RUN tar zxf pgpool.tgz
+
+WORKDIR /usr/local/src/$_pkgname-$PGPOOL_VERSION
+
+ADD script script
+ADD patches patches
+RUN export APPLY_PATCHES
+RUN ./script/apply-patches.sh
+
+RUN ./configure \
+		--prefix=/usr \
+		--sysconfdir=/etc/$pkgname \
+		--mandir=/usr/share/man \
+		--infodir=/usr/share/info \
+		--with-openssl \
+		--disable-rpath
+
+RUN make -j3
+RUN strip src/pgpool
+RUN make DESTDIR=/pgpool_bin install
+
+###
+### build envtpl
+###
 FROM --platform=linux/amd64 golang:1.19-alpine as go_utils
 RUN apk add --no-cache git make build-base python3 curl
 WORKDIR /src
@@ -23,6 +65,9 @@ RUN git clone https://github.com/subfuzion/envtpl
 WORKDIR /src/envtpl
 RUN go install ./cmd/envtpl/...
 
+###
+### put together everything in the deploy image
+###
 FROM --platform=linux/amd64 alpine:${ALPINE_VERSION}
 RUN apk add --no-cache curl python3
 
@@ -48,13 +93,13 @@ RUN apk add --no-cache \
       jq \
       libevent \
       openssl \
-      pgpool \
       postgresql-client
 
 # Adding the package path to local
 ENV PATH $PATH:/usr/local/gcloud/google-cloud-sdk/bin
 
 COPY --from=go_utils /go/bin/envtpl /bin/envtpl
+COPY --from=pgpool_build /pgpool_bin/ /
 
 RUN mkdir /etc/templates
 COPY conf/*.conf /etc/templates/

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ instance no matter what.  This is configureable at deploy time as
 
 Old Version | New Version | Upgrade Guide
 --- | --- | ---
+v1.1.10 | v1.2.0 | [link](UPGRADE.md#v1110--v120)
 v1.1.8 | v1.1.10 | [link](UPGRADE.md#v118--v1110)
 v1.1.9 | v1.1.9 | [link](UPGRADE.md#v118--v119)
 v1.1.7 | v1.1.8 | [link](UPGRADE.md#v117--v118)
@@ -117,8 +118,8 @@ See below for the full list of possible values:
 Parameter | Description | Default
 --- | --- | ---
 `deploy.replicaCount` | Number of pod replicas to deploy | `1`
-`deploy.repository` | Docker image repository of the runtime image | `odentech/pgpool-cloudsql`
-`deploy.tag` | Docker image tag of the runtime image | `1.1.0`
+`deploy.repository` | Docker image repository of the runtime container image | `odentech/pgpool-cloudsql`
+`deploy.tag` | If set, override the tag of the runtime container image. If left empty, we use the concatenation of the chart version (`1.2.0`) and the selected `pgpool.version` e.g. `1.2.0-4.5.0` | `""`
 `deploy.service.tier` | Value for the "tier" [label](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/) applied to the kubernetes [service](https://kubernetes.io/docs/concepts/services-networking/service/) | `db`
 `deploy.service.additionalLabels` | Map of additional k/v string pairs to add as labels for the kubernetes service | `{}`
 `deploy.annotations` | Kubernetes [annotation](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/) spec applied to the deployment pods | `{}`
@@ -230,10 +231,11 @@ Parameter | Description | Default
 
 Parameter | Description | Default
 --- | --- | ---
+`pgpool.version` | Which version of pgpool to deploy. Currently supported: `4.5.0`, `4.4.5`, `4.3.8`, `4.2.15`, `4.1.18`, `4.0.25`  | `4.5.0`
 `pgpool.reservedConnections` | When this parameter is set to 1 or greater, incoming connections from clients are not accepted with error message "Sorry, too many clients already", rather than blocked if the number of current connections from clients is more than (`numInitChildren` - `reservedConnections`). ([docs](https://www.pgpool.net/docs/latest/en/html/runtime-config-connection.html#GUC-RESERVED-CONNECTIONS)) | `0`
 pgpool.processManagmentMode | Whether to use static or dynamic [process management](https://www.pgpool.net/docs/45/en/html/runtime-config-process-management.html). Allowable values are `static` and `dynamic` | `static`
 pgpool.processManagementStrategy | When using [dynamic process managment](https://www.pgpool.net/docs/45/en/html/runtime-config-process-management.html), defines how aggressively to scale down idle connections. Allowable values are `lazy`, `gentle` and `aggressive`. | `gentle`
-pgpool.minSpareChildren | When using [dynamic process management](https://www.pgpool.net/docs/45/en/html/runtime-config-process-management.html), sets the target for the minimum number of spare child processes. | `10`
+pgpool.minSpareChildren | When using [dynamic process management](https://www.pgpool.net/docs/45/en/html/runtime-config-process-management.html), sets the target for the minimum number of spare child processes. | `5`
 pgpool.maxSpareChildren | When using [dynamic process management](https://www.pgpool.net/docs/45/en/html/runtime-config-process-management.html), sets the target for the maximum number of spare child processes. | `10`
 `pgpool.numInitChildren` | This defines the hard limit for concurrent incoming connections: when using static process management pgpool will pre-fork exactly this many children. When using dynamic process management, pgpool will try to maintain a pool of child processes that satisfy the values of minSpareChilden and maxSpareChildren but will never go over numInitChildren. ([docs](https://www.pgpool.net/docs/latest/en/html/runtime-config-connection.html#GUC-NUM-INIT-CHILDREN)) | `32`
 `pgpool.maxPool` | The maximum number of cached connections in each Pgpool-II child process. ([docs](https://www.pgpool.net/docs/latest/en/html/runtime-config-connection.html#GUC-MAX-POOL)) | `32`

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,43 @@
 # Upgrading Steps
 
+## `v1.1.10` → `v1.2.0`
+
+### New features
+
+This release allows runtime picking of a version of PGPool-II from among the multiple
+supported releases:
+
+- `4.5.0`
+- `4.4.5`
+- `4.3.8`
+- `4.2.15`
+- `4.1.18`
+- `4.0.25`
+
+In order to keep deployed image size small, we do this by creating a docker
+image for each combination of chart release and pgpool release, e.g.:
+`odentech/pgpool-cloudsql:1.2.0-4.4.5`.
+
+This means that the behavior of the `deploy.tag` setting has changed subtly: it
+is no longer required, the default value is empty, and if the installer sets a
+non-empty value, that overrides the tag portion of the image entirely. If you
+are setting `deploy.tag` manually, you almost certainly want to be setting
+`deploy.repository` as well!
+
+*WARNING* - dynamic process management is only supported in v4.4 and above: we
+have added a JSONschema values validator and attempting to configure dynamic
+process managment with e.g. `pgpool.version=4.3.8` will fail validation and
+refuse to install.
+
+Also: provide some basic build-time tooling for testing and deploying patches
+to pgpool itself, and document how to do this.
+
+### VALUES - New:
+
+Parameter | Description | Default
+--- | --- | ---
+`pgpool.version` | Pick which version of the actual PGPool-II binary to deploy from among the current release branches. | `4.5.0`
+
 ## `v1.1.9` → `v1.1.10`
 
 ### Software upgrade

--- a/charts/pgpool-cloudsql/Chart.yaml
+++ b/charts/pgpool-cloudsql/Chart.yaml
@@ -15,7 +15,7 @@ apiVersion: v2
 description: the pgpool-ii connection pooling postgres proxy with automatic discovery of GCP CloudSQL backends
 name: pgpool-cloudsql
 type: application
-version: 1.1.10
+version: 1.2.0
 keywords:
 - postgresql
 - pgpool

--- a/charts/pgpool-cloudsql/templates/deployment.yaml
+++ b/charts/pgpool-cloudsql/templates/deployment.yaml
@@ -1,3 +1,8 @@
+{{ if ne .Values.deploy.tag "" -}}
+{{ $_ := set . "image" (print .Values.deploy.repository ":" .Values.deploy.tag) -}}
+{{ else -}}
+{{ $_ := set . "image" (print .Values.deploy.repository ":" .Chart.Version "-" .Values.pgpool.version) -}}
+{{ end -}}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -36,7 +41,7 @@ spec:
 
       containers:
       - name: pgpool
-        image: "{{ .Values.deploy.repository }}:{{ .Values.deploy.tag }}"
+        image: "{{ .image }}"
         imagePullPolicy: Always
         ports:
           - name: postgres-port
@@ -86,7 +91,7 @@ spec:
           value: "{{ .Values.pgpool.coredumpSizeLimit }}"
 
       - name: discovery
-        image: "{{ .Values.deploy.repository }}:{{ .Values.deploy.tag }}"
+        image: "{{ .image }}"
         imagePullPolicy: Always
         {{- with .Values.deploy.resources.discovery }}
         resources:
@@ -163,7 +168,7 @@ spec:
         ports:
           - name: metrics
             containerPort: 9090
-        image: "{{ .Values.deploy.repository }}:{{ .Values.deploy.tag }}"
+        image: "{{ .image }}"
         imagePullPolicy: Always
         {{- with .Values.deploy.resources.exporter }}
         resources:
@@ -220,7 +225,7 @@ spec:
 
       {{- if eq .Values.telegraf.enabled "true" }}
       - name: telegraf
-        image: "{{ .Values.deploy.repository }}:{{ .Values.deploy.tag }}"
+        image: "{{ .image }}"
         imagePullPolicy: Always
         {{- with .Values.deploy.resources.telegraf }}
         resources:

--- a/charts/pgpool-cloudsql/values.schema.json
+++ b/charts/pgpool-cloudsql/values.schema.json
@@ -1,0 +1,1393 @@
+{
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "$id": "http://example.com/example.json",
+    "type": "object",
+    "default": {},
+    "title": "Root Schema",
+    "required": [
+        "deploy",
+        "discovery",
+        "exporter",
+        "telegraf",
+        "pcp",
+        "pgpool"
+    ],
+    "properties": {
+        "deploy": {
+            "type": "object",
+            "default": {},
+            "title": "The deploy Schema",
+            "required": [
+                "replicaCount",
+                "repository",
+                "affinity",
+                "tolerations",
+                "annotations",
+                "resources",
+                "podDisruptionBudget",
+                "service",
+                "startupProbe",
+                "readinessProbe",
+                "livenessProbe"
+            ],
+            "properties": {
+                "replicaCount": {
+                    "type": "integer",
+                    "default": 0,
+                    "title": "The replicaCount Schema",
+                    "examples": [
+                        1
+                    ]
+                },
+                "repository": {
+                    "type": "string",
+                    "default": "odentech/pgpool-cloudsql",
+                    "title": "The repository Schema",
+                    "examples": [
+                        "odentech/pgpool-cloudsql"
+                    ]
+                },
+                "tag": {
+                    "type": "string",
+                    "default": "",
+                    "title": "The tag Schema",
+                    "examples": [
+                        "1.2.0"
+                    ]
+                },
+                "affinity": {
+                    "type": "object",
+                    "default": {},
+                    "title": "The affinity Schema",
+                    "required": [],
+                    "properties": {},
+                    "examples": [{}]
+                },
+                "tolerations": {
+                    "type": "object",
+                    "default": {},
+                    "title": "The tolerations Schema",
+                    "required": [],
+                    "properties": {},
+                    "examples": [{}]
+                },
+                "annotations": {
+                    "type": "object",
+                    "default": {},
+                    "title": "The annotations Schema",
+                    "required": [],
+                    "properties": {},
+                    "examples": [{}]
+                },
+                "resources": {
+                    "type": "object",
+                    "default": {},
+                    "title": "The resources Schema",
+                    "required": [
+                        "pgpool",
+                        "discovery",
+                        "exporter",
+                        "telegraf"
+                    ],
+                    "properties": {
+                        "pgpool": {
+                            "type": "object",
+                            "default": {},
+                            "title": "The pgpool Schema",
+                            "required": [],
+                            "properties": {},
+                            "examples": [{}]
+                        },
+                        "discovery": {
+                            "type": "object",
+                            "default": {},
+                            "title": "The discovery Schema",
+                            "required": [],
+                            "properties": {},
+                            "examples": [{}]
+                        },
+                        "exporter": {
+                            "type": "object",
+                            "default": {},
+                            "title": "The exporter Schema",
+                            "required": [],
+                            "properties": {},
+                            "examples": [{}]
+                        },
+                        "telegraf": {
+                            "type": "object",
+                            "default": {},
+                            "title": "The telegraf Schema",
+                            "required": [],
+                            "properties": {},
+                            "examples": [{}]
+                        }
+                    },
+                    "examples": [{
+                        "pgpool": {},
+                        "discovery": {},
+                        "exporter": {},
+                        "telegraf": {}
+                    }]
+                },
+                "podDisruptionBudget": {
+                    "type": "object",
+                    "default": {},
+                    "title": "The podDisruptionBudget Schema",
+                    "required": [
+                        "maxUnavailable"
+                    ],
+                    "properties": {
+                        "maxUnavailable": {
+                            "type": "integer",
+                            "default": 0,
+                            "title": "The maxUnavailable Schema",
+                            "examples": [
+                                1
+                            ]
+                        }
+                    },
+                    "examples": [{
+                        "maxUnavailable": 1
+                    }]
+                },
+                "service": {
+                    "type": "object",
+                    "default": {},
+                    "title": "The service Schema",
+                    "required": [
+                        "tier",
+                        "additionalLabels"
+                    ],
+                    "properties": {
+                        "tier": {
+                            "type": "string",
+                            "default": "",
+                            "title": "The tier Schema",
+                            "examples": [
+                                "db"
+                            ]
+                        },
+                        "additionalLabels": {
+                            "type": "object",
+                            "default": {},
+                            "title": "The additionalLabels Schema",
+                            "required": [],
+                            "properties": {},
+                            "examples": [{}]
+                        }
+                    },
+                    "examples": [{
+                        "tier": "db",
+                        "additionalLabels": {}
+                    }]
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "default": {},
+                    "title": "The startupProbe Schema",
+                    "required": [
+                        "pgpool",
+                        "exporter"
+                    ],
+                    "properties": {
+                        "pgpool": {
+                            "type": "object",
+                            "default": {},
+                            "title": "The pgpool Schema",
+                            "required": [
+                                "enabled",
+                                "initialDelaySeconds",
+                                "periodSeconds",
+                                "timeoutSeconds",
+                                "successThreshold",
+                                "failureThreshold"
+                            ],
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "default": false,
+                                    "title": "The enabled Schema",
+                                    "examples": [
+                                        true
+                                    ]
+                                },
+                                "initialDelaySeconds": {
+                                    "type": "integer",
+                                    "default": 0,
+                                    "title": "The initialDelaySeconds Schema",
+                                    "examples": [
+                                        5
+                                    ]
+                                },
+                                "periodSeconds": {
+                                    "type": "integer",
+                                    "default": 0,
+                                    "title": "The periodSeconds Schema",
+                                    "examples": [
+                                        5
+                                    ]
+                                },
+                                "timeoutSeconds": {
+                                    "type": "integer",
+                                    "default": 0,
+                                    "title": "The timeoutSeconds Schema",
+                                    "examples": [
+                                        4
+                                    ]
+                                },
+                                "successThreshold": {
+                                    "type": "integer",
+                                    "default": 0,
+                                    "title": "The successThreshold Schema",
+                                    "examples": [
+                                        1
+                                    ]
+                                },
+                                "failureThreshold": {
+                                    "type": "integer",
+                                    "default": 0,
+                                    "title": "The failureThreshold Schema",
+                                    "examples": [
+                                        15
+                                    ]
+                                }
+                            },
+                            "examples": [{
+                                "enabled": true,
+                                "initialDelaySeconds": 5,
+                                "periodSeconds": 5,
+                                "timeoutSeconds": 4,
+                                "successThreshold": 1,
+                                "failureThreshold": 15
+                            }]
+                        },
+                        "exporter": {
+                            "type": "object",
+                            "default": {},
+                            "title": "The exporter Schema",
+                            "required": [
+                                "enabled",
+                                "initialDelaySeconds",
+                                "periodSeconds",
+                                "timeoutSeconds",
+                                "successThreshold",
+                                "failureThreshold"
+                            ],
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "default": false,
+                                    "title": "The enabled Schema",
+                                    "examples": [
+                                        true
+                                    ]
+                                },
+                                "initialDelaySeconds": {
+                                    "type": "integer",
+                                    "default": 0,
+                                    "title": "The initialDelaySeconds Schema",
+                                    "examples": [
+                                        5
+                                    ]
+                                },
+                                "periodSeconds": {
+                                    "type": "integer",
+                                    "default": 0,
+                                    "title": "The periodSeconds Schema",
+                                    "examples": [
+                                        5
+                                    ]
+                                },
+                                "timeoutSeconds": {
+                                    "type": "integer",
+                                    "default": 0,
+                                    "title": "The timeoutSeconds Schema",
+                                    "examples": [
+                                        4
+                                    ]
+                                },
+                                "successThreshold": {
+                                    "type": "integer",
+                                    "default": 0,
+                                    "title": "The successThreshold Schema",
+                                    "examples": [
+                                        1
+                                    ]
+                                },
+                                "failureThreshold": {
+                                    "type": "integer",
+                                    "default": 0,
+                                    "title": "The failureThreshold Schema",
+                                    "examples": [
+                                        15
+                                    ]
+                                }
+                            },
+                            "examples": [{
+                                "enabled": true,
+                                "initialDelaySeconds": 5,
+                                "periodSeconds": 5,
+                                "timeoutSeconds": 4,
+                                "successThreshold": 1,
+                                "failureThreshold": 15
+                            }]
+                        }
+                    },
+                    "examples": [{
+                        "pgpool": {
+                            "enabled": true,
+                            "initialDelaySeconds": 5,
+                            "periodSeconds": 5,
+                            "timeoutSeconds": 4,
+                            "successThreshold": 1,
+                            "failureThreshold": 15
+                        },
+                        "exporter": {
+                            "enabled": true,
+                            "initialDelaySeconds": 5,
+                            "periodSeconds": 5,
+                            "timeoutSeconds": 4,
+                            "successThreshold": 1,
+                            "failureThreshold": 15
+                        }
+                    }]
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "default": {},
+                    "title": "The readinessProbe Schema",
+                    "required": [
+                        "pgpool",
+                        "exporter"
+                    ],
+                    "properties": {
+                        "pgpool": {
+                            "type": "object",
+                            "default": {},
+                            "title": "The pgpool Schema",
+                            "required": [
+                                "enabled",
+                                "initialDelaySeconds",
+                                "periodSeconds",
+                                "timeoutSeconds",
+                                "successThreshold",
+                                "failureThreshold"
+                            ],
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "default": false,
+                                    "title": "The enabled Schema",
+                                    "examples": [
+                                        true
+                                    ]
+                                },
+                                "initialDelaySeconds": {
+                                    "type": "integer",
+                                    "default": 0,
+                                    "title": "The initialDelaySeconds Schema",
+                                    "examples": [
+                                        5
+                                    ]
+                                },
+                                "periodSeconds": {
+                                    "type": "integer",
+                                    "default": 0,
+                                    "title": "The periodSeconds Schema",
+                                    "examples": [
+                                        5
+                                    ]
+                                },
+                                "timeoutSeconds": {
+                                    "type": "integer",
+                                    "default": 0,
+                                    "title": "The timeoutSeconds Schema",
+                                    "examples": [
+                                        4
+                                    ]
+                                },
+                                "successThreshold": {
+                                    "type": "integer",
+                                    "default": 0,
+                                    "title": "The successThreshold Schema",
+                                    "examples": [
+                                        1
+                                    ]
+                                },
+                                "failureThreshold": {
+                                    "type": "integer",
+                                    "default": 0,
+                                    "title": "The failureThreshold Schema",
+                                    "examples": [
+                                        2
+                                    ]
+                                }
+                            },
+                            "examples": [{
+                                "enabled": true,
+                                "initialDelaySeconds": 5,
+                                "periodSeconds": 5,
+                                "timeoutSeconds": 4,
+                                "successThreshold": 1,
+                                "failureThreshold": 2
+                            }]
+                        },
+                        "exporter": {
+                            "type": "object",
+                            "default": {},
+                            "title": "The exporter Schema",
+                            "required": [
+                                "enabled",
+                                "initialDelaySeconds",
+                                "periodSeconds",
+                                "timeoutSeconds",
+                                "successThreshold",
+                                "failureThreshold"
+                            ],
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "default": false,
+                                    "title": "The enabled Schema",
+                                    "examples": [
+                                        true
+                                    ]
+                                },
+                                "initialDelaySeconds": {
+                                    "type": "integer",
+                                    "default": 0,
+                                    "title": "The initialDelaySeconds Schema",
+                                    "examples": [
+                                        5
+                                    ]
+                                },
+                                "periodSeconds": {
+                                    "type": "integer",
+                                    "default": 0,
+                                    "title": "The periodSeconds Schema",
+                                    "examples": [
+                                        5
+                                    ]
+                                },
+                                "timeoutSeconds": {
+                                    "type": "integer",
+                                    "default": 0,
+                                    "title": "The timeoutSeconds Schema",
+                                    "examples": [
+                                        4
+                                    ]
+                                },
+                                "successThreshold": {
+                                    "type": "integer",
+                                    "default": 0,
+                                    "title": "The successThreshold Schema",
+                                    "examples": [
+                                        1
+                                    ]
+                                },
+                                "failureThreshold": {
+                                    "type": "integer",
+                                    "default": 0,
+                                    "title": "The failureThreshold Schema",
+                                    "examples": [
+                                        2
+                                    ]
+                                }
+                            },
+                            "examples": [{
+                                "enabled": true,
+                                "initialDelaySeconds": 5,
+                                "periodSeconds": 5,
+                                "timeoutSeconds": 4,
+                                "successThreshold": 1,
+                                "failureThreshold": 2
+                            }]
+                        }
+                    },
+                    "examples": [{
+                        "pgpool": {
+                            "enabled": true,
+                            "initialDelaySeconds": 5,
+                            "periodSeconds": 5,
+                            "timeoutSeconds": 4,
+                            "successThreshold": 1,
+                            "failureThreshold": 2
+                        },
+                        "exporter": {
+                            "enabled": true,
+                            "initialDelaySeconds": 5,
+                            "periodSeconds": 5,
+                            "timeoutSeconds": 4,
+                            "successThreshold": 1,
+                            "failureThreshold": 2
+                        }
+                    }]
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "default": {},
+                    "title": "The livenessProbe Schema",
+                    "required": [
+                        "pgpool",
+                        "exporter"
+                    ],
+                    "properties": {
+                        "pgpool": {
+                            "type": "object",
+                            "default": {},
+                            "title": "The pgpool Schema",
+                            "required": [
+                                "enabled",
+                                "initialDelaySeconds",
+                                "periodSeconds",
+                                "timeoutSeconds",
+                                "successThreshold",
+                                "failureThreshold"
+                            ],
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "default": false,
+                                    "title": "The enabled Schema",
+                                    "examples": [
+                                        true
+                                    ]
+                                },
+                                "initialDelaySeconds": {
+                                    "type": "integer",
+                                    "default": 0,
+                                    "title": "The initialDelaySeconds Schema",
+                                    "examples": [
+                                        5
+                                    ]
+                                },
+                                "periodSeconds": {
+                                    "type": "integer",
+                                    "default": 0,
+                                    "title": "The periodSeconds Schema",
+                                    "examples": [
+                                        5
+                                    ]
+                                },
+                                "timeoutSeconds": {
+                                    "type": "integer",
+                                    "default": 0,
+                                    "title": "The timeoutSeconds Schema",
+                                    "examples": [
+                                        4
+                                    ]
+                                },
+                                "successThreshold": {
+                                    "type": "integer",
+                                    "default": 0,
+                                    "title": "The successThreshold Schema",
+                                    "examples": [
+                                        1
+                                    ]
+                                },
+                                "failureThreshold": {
+                                    "type": "integer",
+                                    "default": 0,
+                                    "title": "The failureThreshold Schema",
+                                    "examples": [
+                                        5
+                                    ]
+                                }
+                            },
+                            "examples": [{
+                                "enabled": true,
+                                "initialDelaySeconds": 5,
+                                "periodSeconds": 5,
+                                "timeoutSeconds": 4,
+                                "successThreshold": 1,
+                                "failureThreshold": 5
+                            }]
+                        },
+                        "exporter": {
+                            "type": "object",
+                            "default": {},
+                            "title": "The exporter Schema",
+                            "required": [
+                                "enabled",
+                                "initialDelaySeconds",
+                                "periodSeconds",
+                                "timeoutSeconds",
+                                "successThreshold",
+                                "failureThreshold"
+                            ],
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "default": false,
+                                    "title": "The enabled Schema",
+                                    "examples": [
+                                        true
+                                    ]
+                                },
+                                "initialDelaySeconds": {
+                                    "type": "integer",
+                                    "default": 0,
+                                    "title": "The initialDelaySeconds Schema",
+                                    "examples": [
+                                        5
+                                    ]
+                                },
+                                "periodSeconds": {
+                                    "type": "integer",
+                                    "default": 0,
+                                    "title": "The periodSeconds Schema",
+                                    "examples": [
+                                        5
+                                    ]
+                                },
+                                "timeoutSeconds": {
+                                    "type": "integer",
+                                    "default": 0,
+                                    "title": "The timeoutSeconds Schema",
+                                    "examples": [
+                                        4
+                                    ]
+                                },
+                                "successThreshold": {
+                                    "type": "integer",
+                                    "default": 0,
+                                    "title": "The successThreshold Schema",
+                                    "examples": [
+                                        1
+                                    ]
+                                },
+                                "failureThreshold": {
+                                    "type": "integer",
+                                    "default": 0,
+                                    "title": "The failureThreshold Schema",
+                                    "examples": [
+                                        5
+                                    ]
+                                }
+                            },
+                            "examples": [{
+                                "enabled": true,
+                                "initialDelaySeconds": 5,
+                                "periodSeconds": 5,
+                                "timeoutSeconds": 4,
+                                "successThreshold": 1,
+                                "failureThreshold": 5
+                            }]
+                        }
+                    },
+                    "examples": [{
+                        "pgpool": {
+                            "enabled": true,
+                            "initialDelaySeconds": 5,
+                            "periodSeconds": 5,
+                            "timeoutSeconds": 4,
+                            "successThreshold": 1,
+                            "failureThreshold": 5
+                        },
+                        "exporter": {
+                            "enabled": true,
+                            "initialDelaySeconds": 5,
+                            "periodSeconds": 5,
+                            "timeoutSeconds": 4,
+                            "successThreshold": 1,
+                            "failureThreshold": 5
+                        }
+                    }]
+                }
+            },
+            "examples": [{
+                "replicaCount": 1,
+                "repository": "odentech/pgpool-cloudsql",
+                "affinity": {},
+                "tolerations": {},
+                "annotations": {},
+                "resources": {
+                    "pgpool": {},
+                    "discovery": {},
+                    "exporter": {},
+                    "telegraf": {}
+                },
+                "podDisruptionBudget": {
+                    "maxUnavailable": 1
+                },
+                "service": {
+                    "tier": "db",
+                    "additionalLabels": {}
+                },
+                "startupProbe": {
+                    "pgpool": {
+                        "enabled": true,
+                        "initialDelaySeconds": 5,
+                        "periodSeconds": 5,
+                        "timeoutSeconds": 4,
+                        "successThreshold": 1,
+                        "failureThreshold": 15
+                    },
+                    "exporter": {
+                        "enabled": true,
+                        "initialDelaySeconds": 5,
+                        "periodSeconds": 5,
+                        "timeoutSeconds": 4,
+                        "successThreshold": 1,
+                        "failureThreshold": 15
+                    }
+                },
+                "readinessProbe": {
+                    "pgpool": {
+                        "enabled": true,
+                        "initialDelaySeconds": 5,
+                        "periodSeconds": 5,
+                        "timeoutSeconds": 4,
+                        "successThreshold": 1,
+                        "failureThreshold": 2
+                    },
+                    "exporter": {
+                        "enabled": true,
+                        "initialDelaySeconds": 5,
+                        "periodSeconds": 5,
+                        "timeoutSeconds": 4,
+                        "successThreshold": 1,
+                        "failureThreshold": 2
+                    }
+                },
+                "livenessProbe": {
+                    "pgpool": {
+                        "enabled": true,
+                        "initialDelaySeconds": 5,
+                        "periodSeconds": 5,
+                        "timeoutSeconds": 4,
+                        "successThreshold": 1,
+                        "failureThreshold": 5
+                    },
+                    "exporter": {
+                        "enabled": true,
+                        "initialDelaySeconds": 5,
+                        "periodSeconds": 5,
+                        "timeoutSeconds": 4,
+                        "successThreshold": 1,
+                        "failureThreshold": 5
+                    }
+                }
+            }]
+        },
+        "discovery": {
+            "type": "object",
+            "default": {},
+            "title": "The discovery Schema",
+            "required": [
+                "primaryInstancePrefix",
+                "stayInRegion",
+                "pruneThreshold"
+            ],
+            "properties": {
+                "primaryInstancePrefix": {
+                    "type": "string",
+                    "default": "",
+                    "title": "The primaryInstancePrefix Schema",
+                    "examples": [
+                        ""
+                    ]
+                },
+                "stayInRegion": {
+                    "type": "boolean",
+                    "default": false,
+                    "title": "The stayInRegion Schema",
+                    "examples": [
+                        true
+                    ]
+                },
+                "pruneThreshold": {
+                    "type": "integer",
+                    "default": 0,
+                    "title": "The pruneThreshold Schema",
+                    "examples": [
+                        900
+                    ]
+                }
+            },
+            "examples": [{
+                "primaryInstancePrefix": "",
+                "stayInRegion": true,
+                "pruneThreshold": 900
+            }]
+        },
+        "exporter": {
+            "type": "object",
+            "default": {},
+            "title": "The exporter Schema",
+            "required": [
+                "postgresUsername",
+                "postgresPassword",
+                "postgresDatabase",
+                "exitOnError"
+            ],
+            "properties": {
+                "postgresUsername": {
+                    "type": "string",
+                    "default": "",
+                    "title": "The postgresUsername Schema",
+                    "examples": [
+                        ""
+                    ]
+                },
+                "postgresPassword": {
+                    "type": "string",
+                    "default": "",
+                    "title": "The postgresPassword Schema",
+                    "examples": [
+                        ""
+                    ]
+                },
+                "postgresDatabase": {
+                    "type": "string",
+                    "default": "",
+                    "title": "The postgresDatabase Schema",
+                    "examples": [
+                        "postgres"
+                    ]
+                },
+                "exitOnError": {
+                    "type": "string",
+                    "default": "",
+                    "title": "The exitOnError Schema",
+                    "examples": [
+                        "false"
+                    ]
+                }
+            },
+            "examples": [{
+                "postgresUsername": "",
+                "postgresPassword": "",
+                "postgresDatabase": "postgres",
+                "exitOnError": "false"
+            }]
+        },
+        "telegraf": {
+            "type": "object",
+            "default": {},
+            "title": "The telegraf Schema",
+            "required": [
+                "enabled",
+                "exitOnError"
+            ],
+            "properties": {
+                "enabled": {
+                    "type": "string",
+                    "default": "",
+                    "title": "The enabled Schema",
+                    "examples": [
+                        "true"
+                    ]
+                },
+                "exitOnError": {
+                    "type": "string",
+                    "default": "",
+                    "title": "The exitOnError Schema",
+                    "examples": [
+                        "false"
+                    ]
+                }
+            },
+            "examples": [{
+                "enabled": "true",
+                "exitOnError": "false"
+            }]
+        },
+        "pcp": {
+            "type": "object",
+            "default": {},
+            "title": "The pcp Schema",
+            "required": [
+                "password"
+            ],
+            "properties": {
+                "password": {
+                    "type": "string",
+                    "default": "",
+                    "title": "The password Schema",
+                    "examples": [
+                        ""
+                    ]
+                }
+            },
+            "examples": [{
+                "password": ""
+            }]
+        },
+        "pgpool": {
+            "type": "object",
+            "default": {},
+            "title": "The pgpool Schema",
+            "required": [
+                "version",
+                "processManagementMode",
+                "processManagementStrategy",
+                "minSpareChildren",
+                "maxSpareChildren",
+                "reservedConnections",
+                "numInitChildren",
+                "maxPool",
+                "childLifeTime",
+                "childMaxConnections",
+                "connectionLifeTime",
+                "clientIdleLimit",
+                "ignoreLeadingWhiteSpace",
+                "primaryRoutingQueryPatternList",
+                "allowSqlComments",
+                "disableLoadBalanceOnWrite",
+                "statementLevelLoadBalance",
+                "primaryWeight",
+                "replicasWeight",
+                "logMinMessages",
+                "logErrorVerbosity",
+                "srCheckUsername",
+                "srCheckPassword",
+                "srCheckDatabase",
+                "healthCheckUsername",
+                "healthCheckPassword",
+                "healthCheckDatabase",
+                "coredumpSizeLimit"
+            ],
+            "if": {
+              "properties": {
+                "version": {
+                  "message": {
+                    "pattern": "process mgmt mode must be static for pgpool.version prior to 4.4"
+                  },
+                  "pattern": "^4\\.[0-3]\\..*$"
+                }
+              }
+            },
+            "then": {
+              "properties": {
+                "processManagementMode": {
+                  "message": {
+                    "const": "process mgmt mode must be static for pgpool.version prior to 4.4"
+                  },
+                  "const": "static"
+                }
+              }
+            },
+            "else": {
+              "properties": {
+                "processManagementMode": {
+                  "message": {
+                    "enum": "process mgmt mode must be static for pgpool.version prior to 4.4"
+                  },
+                  "enum": [
+                    "static",
+                    "dynamic"
+                  ]
+                }
+              }
+            },
+            "properties": {
+                "version": {
+                    "type": "string",
+                    "default": "4.5.0",
+                    "title": "The version Schema",
+                    "examples": [
+                        "4.5.0"
+                    ],
+                    "message": {
+                      "enum": "process mgmt mode must be static for pgpool.version prior to 4.4",
+                      "pattern": "process mgmt mode must be static for pgpool.version prior to 4.4"
+                    },
+                    "enum": [
+                      "4.5.0",
+                      "4.4.5",
+                      "4.3.8",
+                      "4.2.15",
+                      "4.1.18",
+                      "4.0.25"
+                    ]
+                },
+                "processManagementMode": {
+                    "type": "string",
+                    "default": "static",
+                    "title": "The processManagementMode Schema",
+                    "examples": [
+                        "static"
+                    ],
+                    "message": {
+                      "enum": "process mgmt mode must be static for pgpool.version prior to 4.4",
+                      "const": "process mgmt mode must be static for pgpool.version prior to 4.4"
+                    },
+                    "enum": [
+                      "static",
+                      "dynamic"
+                    ]
+                },
+                "processManagementStrategy": {
+                    "type": "string",
+                    "default": "",
+                    "title": "The processManagementStrategy Schema",
+                    "examples": [
+                        "gentle"
+                    ],
+                    "enum": [
+                      "lazy",
+                      "gentle",
+                      "aggressive"
+                    ]
+                },
+                "minSpareChildren": {
+                    "type": "integer",
+                    "default": 0,
+                    "title": "The minSpareChildren Schema",
+                    "examples": [
+                        5
+                    ]
+                },
+                "maxSpareChildren": {
+                    "type": "integer",
+                    "default": 0,
+                    "title": "The maxSpareChildren Schema",
+                    "examples": [
+                        10
+                    ]
+                },
+                "reservedConnections": {
+                    "type": "integer",
+                    "default": 0,
+                    "title": "The reservedConnections Schema",
+                    "examples": [
+                        0
+                    ]
+                },
+                "numInitChildren": {
+                    "type": "integer",
+                    "default": 0,
+                    "title": "The numInitChildren Schema",
+                    "examples": [
+                        32
+                    ]
+                },
+                "maxPool": {
+                    "type": "integer",
+                    "default": 0,
+                    "title": "The maxPool Schema",
+                    "examples": [
+                        32
+                    ]
+                },
+                "childLifeTime": {
+                    "type": "string",
+                    "default": "",
+                    "title": "The childLifeTime Schema",
+                    "examples": [
+                        "5min"
+                    ]
+                },
+                "childMaxConnections": {
+                    "type": "integer",
+                    "default": 0,
+                    "title": "The childMaxConnections Schema",
+                    "examples": [
+                        8192
+                    ]
+                },
+                "connectionLifeTime": {
+                    "type": "integer",
+                    "default": 0,
+                    "title": "The connectionLifeTime Schema",
+                    "examples": [
+                        0
+                    ]
+                },
+                "clientIdleLimit": {
+                    "type": "integer",
+                    "default": 0,
+                    "title": "The clientIdleLimit Schema",
+                    "examples": [
+                        300
+                    ]
+                },
+                "ignoreLeadingWhiteSpace": {
+                    "type": "string",
+                    "default": "",
+                    "title": "The ignoreLeadingWhiteSpace Schema",
+                    "examples": [
+                        "on"
+                    ]
+                },
+                "primaryRoutingQueryPatternList": {
+                    "type": "string",
+                    "default": "",
+                    "title": "The primaryRoutingQueryPatternList Schema",
+                    "examples": [
+                        ".*DO NOT LOAD BALANCE.*"
+                    ]
+                },
+                "allowSqlComments": {
+                    "type": "string",
+                    "default": "",
+                    "title": "The allowSqlComments Schema",
+                    "examples": [
+                        "on"
+                    ]
+                },
+                "disableLoadBalanceOnWrite": {
+                    "type": "string",
+                    "default": "",
+                    "title": "The disableLoadBalanceOnWrite Schema",
+                    "examples": [
+                        "transaction"
+                    ]
+                },
+                "statementLevelLoadBalance": {
+                    "type": "string",
+                    "default": "",
+                    "title": "The statementLevelLoadBalance Schema",
+                    "examples": [
+                        "on"
+                    ]
+                },
+                "primaryWeight": {
+                    "type": "integer",
+                    "default": 0,
+                    "title": "The primaryWeight Schema",
+                    "examples": [
+                        0
+                    ]
+                },
+                "replicasWeight": {
+                    "type": "integer",
+                    "default": 0,
+                    "title": "The replicasWeight Schema",
+                    "examples": [
+                        1
+                    ]
+                },
+                "logMinMessages": {
+                    "type": "string",
+                    "default": "",
+                    "title": "The logMinMessages Schema",
+                    "examples": [
+                        "ERROR"
+                    ]
+                },
+                "logErrorVerbosity": {
+                    "type": "string",
+                    "default": "",
+                    "title": "The logErrorVerbosity Schema",
+                    "examples": [
+                        "TERSE"
+                    ]
+                },
+                "srCheckUsername": {
+                    "type": "string",
+                    "default": "",
+                    "title": "The srCheckUsername Schema",
+                    "examples": [
+                        ""
+                    ]
+                },
+                "srCheckPassword": {
+                    "type": "string",
+                    "default": "",
+                    "title": "The srCheckPassword Schema",
+                    "examples": [
+                        ""
+                    ]
+                },
+                "srCheckDatabase": {
+                    "type": "string",
+                    "default": "",
+                    "title": "The srCheckDatabase Schema",
+                    "examples": [
+                        "postgres"
+                    ]
+                },
+                "healthCheckUsername": {
+                    "type": "string",
+                    "default": "",
+                    "title": "The healthCheckUsername Schema",
+                    "examples": [
+                        ""
+                    ]
+                },
+                "healthCheckPassword": {
+                    "type": "string",
+                    "default": "",
+                    "title": "The healthCheckPassword Schema",
+                    "examples": [
+                        ""
+                    ]
+                },
+                "healthCheckDatabase": {
+                    "type": "string",
+                    "default": "",
+                    "title": "The healthCheckDatabase Schema",
+                    "examples": [
+                        "postgres"
+                    ]
+                },
+                "coredumpSizeLimit": {
+                    "type": "string",
+                    "default": "",
+                    "title": "The coredumpSizeLimit Schema",
+                    "examples": [
+                        "0"
+                    ]
+                }
+            },
+            "examples": [{
+                "version": "4.5.0",
+                "processManagementMode": "static",
+                "processManagementStrategy": "gentle",
+                "minSpareChildren": 5,
+                "maxSpareChildren": 10,
+                "reservedConnections": 0,
+                "numInitChildren": 32,
+                "maxPool": 32,
+                "childLifeTime": "5min",
+                "childMaxConnections": 8192,
+                "connectionLifeTime": 0,
+                "clientIdleLimit": 300,
+                "ignoreLeadingWhiteSpace": "on",
+                "primaryRoutingQueryPatternList": ".*DO NOT LOAD BALANCE.*",
+                "allowSqlComments": "on",
+                "disableLoadBalanceOnWrite": "transaction",
+                "statementLevelLoadBalance": "on",
+                "primaryWeight": 0,
+                "replicasWeight": 1,
+                "logMinMessages": "ERROR",
+                "logErrorVerbosity": "TERSE",
+                "srCheckUsername": "",
+                "srCheckPassword": "",
+                "srCheckDatabase": "postgres",
+                "healthCheckUsername": "",
+                "healthCheckPassword": "",
+                "healthCheckDatabase": "postgres",
+                "coredumpSizeLimit": "0"
+            }]
+        }
+    },
+    "examples": [{
+        "deploy": {
+            "replicaCount": 1,
+            "repository": "odentech/pgpool-cloudsql",
+            "tag": "1.1.10",
+            "affinity": {},
+            "tolerations": {},
+            "annotations": {},
+            "resources": {
+                "pgpool": {},
+                "discovery": {},
+                "exporter": {},
+                "telegraf": {}
+            },
+            "podDisruptionBudget": {
+                "maxUnavailable": 1
+            },
+            "service": {
+                "tier": "db",
+                "additionalLabels": {}
+            },
+            "startupProbe": {
+                "pgpool": {
+                    "enabled": true,
+                    "initialDelaySeconds": 5,
+                    "periodSeconds": 5,
+                    "timeoutSeconds": 4,
+                    "successThreshold": 1,
+                    "failureThreshold": 15
+                },
+                "exporter": {
+                    "enabled": true,
+                    "initialDelaySeconds": 5,
+                    "periodSeconds": 5,
+                    "timeoutSeconds": 4,
+                    "successThreshold": 1,
+                    "failureThreshold": 15
+                }
+            },
+            "readinessProbe": {
+                "pgpool": {
+                    "enabled": true,
+                    "initialDelaySeconds": 5,
+                    "periodSeconds": 5,
+                    "timeoutSeconds": 4,
+                    "successThreshold": 1,
+                    "failureThreshold": 2
+                },
+                "exporter": {
+                    "enabled": true,
+                    "initialDelaySeconds": 5,
+                    "periodSeconds": 5,
+                    "timeoutSeconds": 4,
+                    "successThreshold": 1,
+                    "failureThreshold": 2
+                }
+            },
+            "livenessProbe": {
+                "pgpool": {
+                    "enabled": true,
+                    "initialDelaySeconds": 5,
+                    "periodSeconds": 5,
+                    "timeoutSeconds": 4,
+                    "successThreshold": 1,
+                    "failureThreshold": 5
+                },
+                "exporter": {
+                    "enabled": true,
+                    "initialDelaySeconds": 5,
+                    "periodSeconds": 5,
+                    "timeoutSeconds": 4,
+                    "successThreshold": 1,
+                    "failureThreshold": 5
+                }
+            }
+        },
+        "discovery": {
+            "primaryInstancePrefix": "",
+            "stayInRegion": true,
+            "pruneThreshold": 900
+        },
+        "exporter": {
+            "postgresUsername": "",
+            "postgresPassword": "",
+            "postgresDatabase": "postgres",
+            "exitOnError": "false"
+        },
+        "telegraf": {
+            "enabled": "true",
+            "exitOnError": "false"
+        },
+        "pcp": {
+            "password": ""
+        },
+        "pgpool": {
+            "version": "4.5.0",
+            "processManagementMode": "static",
+            "processManagementStrategy": "gentle",
+            "minSpareChildren": 5,
+            "maxSpareChildren": 10,
+            "reservedConnections": 0,
+            "numInitChildren": 32,
+            "maxPool": 32,
+            "childLifeTime": "5min",
+            "childMaxConnections": 8192,
+            "connectionLifeTime": 0,
+            "clientIdleLimit": 300,
+            "ignoreLeadingWhiteSpace": "on",
+            "primaryRoutingQueryPatternList": ".*DO NOT LOAD BALANCE.*",
+            "allowSqlComments": "on",
+            "disableLoadBalanceOnWrite": "transaction",
+            "statementLevelLoadBalance": "on",
+            "primaryWeight": 0,
+            "replicasWeight": 1,
+            "logMinMessages": "ERROR",
+            "logErrorVerbosity": "TERSE",
+            "srCheckUsername": "",
+            "srCheckPassword": "",
+            "srCheckDatabase": "postgres",
+            "healthCheckUsername": "",
+            "healthCheckPassword": "",
+            "healthCheckDatabase": "postgres",
+            "coredumpSizeLimit": "0"
+        }
+    }]
+}

--- a/charts/pgpool-cloudsql/values.yaml
+++ b/charts/pgpool-cloudsql/values.yaml
@@ -15,7 +15,7 @@
 deploy:
   replicaCount: 1
   repository: odentech/pgpool-cloudsql
-  tag: 1.1.10
+  tag: ""
   affinity: {}
     # # pin tasks to the default node pool
     # nodeAffinity:
@@ -139,14 +139,24 @@ pcp:
   password: ""
 
 pgpool:
+  # what version of pgpool to use!  Currently supported versions are:
+  # 4.5.0
+  # 4.4.5
+  # 4.3.8
+  # 4.2.15
+  # 4.1.18
+  # 4.0.25
+  version: "4.5.0"
   # whether to use static or dynamic process management mode; see
   # https://www.pgpool.net/docs/45/en/html/runtime-config-process-management.html
   # allowed values are "static" and "dynamic"
+  # WARNING: dynamic process management is only available when using pgpool
+  # versions 4.4.0 and above
   processManagementMode: "static"
   # configure scale-in/out strategy when using "dynamic" process management;
   # allowed values are "lazy", "gentle" and "aggressive"
   # (this is ignored if pgpool.processManagementMode is "static"
-  processManagementStragegy: "gentle"
+  processManagementStrategy: "gentle"
   # minimum number of spare child processes to maintain if using dyamic
   # process management mode (ignored when using static mode)
   minSpareChildren: 5
@@ -158,9 +168,9 @@ pgpool:
   # num_init_children - reserved_connections.
   reservedConnections: 0
   # the hard limit for concurrent incoming connections: when using static process
-  # management pgpool will pre-fork exactly this many children. When using dynamic 
-  # process management, pgpool will try to maintain a pool of child processes that 
-  # satisfy the values of minSpareChilden and maxSpareChildren but will never go 
+  # management pgpool will pre-fork exactly this many children. When using dynamic
+  # process management, pgpool will try to maintain a pool of child processes that
+  # satisfy the values of minSpareChilden and maxSpareChildren but will never go
   # over numInitChildren
   numInitChildren: 32
   # Maximum number of cached backend connections in each pgpool child process.

--- a/patches/000_unexempt_postgres_db.patch
+++ b/patches/000_unexempt_postgres_db.patch
@@ -1,0 +1,12 @@
+diff --git a/src/protocol/child.c b/src/protocol/child.c
+index d334dad3c..77a4337e9 100644
+--- a/src/protocol/child.c
++++ b/src/protocol/child.c
+@@ -562,7 +562,6 @@ backend_cleanup(POOL_CONNECTION * volatile *frontend, POOL_CONNECTION_POOL * vol
+ 		if ((sp &&
+ 			 (!strcmp(sp->database, "template0") ||
+ 			  !strcmp(sp->database, "template1") ||
+-			  !strcmp(sp->database, "postgres") ||
+ 			  !strcmp(sp->database, "regression"))) ||
+ 			(*frontend != NULL &&
+ 			 ((*frontend)->socket_state == POOL_SOCKET_EOF ||

--- a/patches/README.md
+++ b/patches/README.md
@@ -1,0 +1,34 @@
+# experimental patches and how to use them
+
+**THESE PATCHES ARE NEVER APPLIED IN THE PUBLIC odentech/pgpool-cloudsql DOCKER REPO**
+
+If you perchance wish to test a patch to pgpool2 in your deployment of
+pgpool-cloudsql, you will need to build your own docker images and then
+override the default docker repository when deploying the helm chart.
+
+## Build your own docker images
+
+The `script/build-docker.sh` tool will build and push release docker images
+for pgpool-cloudsql with every patch found in this directory applied sequentially.
+
+By default this will attempt to push to the `odentech/pgpool-cloudsql` docker hub
+repository. However you, person reading this, probably don't have write access to
+that repo, so you'll need to use your own, e.g.:
+
+```sh
+REPOSITORY=mydockerid/pgpool-cloudsql ./script/build-docker.sh
+```
+
+...but replace "mydockerid/pgpool-cloudsql" with the name of your own docker
+hub (or other) container image repository.
+
+The script will automatically produce image tags in the default format of
+`chart_version-pgpool_version`.
+
+## Deploy with your custom images
+
+When deploying, you will need to overwrite the default value of `deploy.repository`:
+
+```sh
+helm install --set deploy.repository=mydockerid/pgpool-cloudsql pgpool-cloudsql pgpool-cloudsql
+```

--- a/script/apply-patches.sh
+++ b/script/apply-patches.sh
@@ -1,0 +1,11 @@
+#!/bin/sh -ex
+#
+
+if [ "${APPLY_PATCHES}" == "true" ]; then
+  for f in patches/*; do
+    echo "*** Applying prebuild patch: ${f}"
+    patch -p1 -u -s <"${f}"
+  done
+else
+  echo "*** Skipping patch apply"
+fi

--- a/script/build-docker.sh
+++ b/script/build-docker.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+#
+
+# warning: this is not meant for external use and will fail badly
+# in most cases.  This is used internally as a backstop for when the incredibly
+# fussy github action fails.
+#
+
+TOP="$(git rev-parse --show-toplevel)"
+
+cd "${TOP}"
+
+CHART_VERSION="$(yq eval '.version' <charts/pgpool-cloudsql/Chart.yaml)"
+
+REPOSITORY="${REPOSITORY:-"odentech/pgpool-cloudsql"}"
+
+yq eval '.jobs.docker_build.strategy.matrix.pgpool_version[]' <.github/workflows/docker.yaml | while read PGPOOL_VERSION; do
+  tag="${REPOSITORY}:${CHART_VERSION}-${PGPOOL_VERSION}"
+  echo "*** Building ${tag}"
+  docker build \
+    --build-arg PGPOOL_VERSION="${PGPOOL_VERSION}" \
+    --build-arg APPLY_PATCHES="TRUE" \
+    --pull \
+    -t "${tag}" \
+    --push \
+    .
+done


### PR DESCRIPTION
- Add the ability to pick the latest patch release of any of the currently supported minor versions of pgpool 4.x

- Updates to the docker workflow to support the above.

- Add tooling to allow local testing of pgpool patches