### PR TITLE
add option to exclude CloudSQL replicas by label

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,9 @@ The primary moving parts are:
 - A [discovery](bin/discovery.sh) script that runs in a separate container.  Once a minute, this script:
      - Uses the `gcloud` cli to list any primary dbs that match the `PRIMARY_INSTANCE_PREFIX` env
        variable as a prefix. (i.e. a prefix of `metadata-` matches `metadata-4093504851`)
-     - Lists all currently active read replicas of the primary database
+     - Lists all currently active read replicas of the primary database, excluding any
+       that have a GCP label matching `REPLICA_SKIP_LABEL` set to `true` (see
+       `discovery.replicaSkipLabel`)
      - Uses the [envtpl](https://github.com/subfuzion/envtpl) tool to fill out [pgpool.conf.tmpl](conf/pgpool.conf.tmpl)
        and copy the result into `/etc/pgpool/pgpool.conf` if it differs from what is already there.
      - If replicas have been added or removed, it runs [pcp_reload_config](https://www.pgpool.net/docs/42/en/html/pcp-reload-config.html)
@@ -44,6 +46,7 @@ instance no matter what.  This is configureable at deploy time as
 
 Old Version | New Version | Upgrade Guide
 --- | --- | ---
+v1.4.1 | v1.5.0 | [link](UPGRADE.md#v141--v150)
 v1.4.0 | v1.4.1 | [link](UPGRADE.md#v140--v141)
 v1.3.3 | v1.4.0 | [link](UPGRADE.md#v133--v140)
 v1.3.2 | v1.3.3 | [link](UPGRADE.md#v132--v133)
@@ -77,7 +80,7 @@ helm repo update
 ```sh
 export RELEASE_NAME=my-pgpool-service # a name (you will need 1 installed chart for each primary DB)
 export NAMESPACE=my-k8s-namespace     # a kubernetes namespace
-export CHART_VERSION=1.4.1            # a chart version: https://github.com/odenio/pgpool-cloudsql/releases
+export CHART_VERSION=1.5.0            # a chart version: https://github.com/odenio/pgpool-cloudsql/releases
 export VALUES_FILE=./my_values.yaml   # your values file
 
 helm install \
@@ -188,6 +191,7 @@ Parameter | Description | Default
 Parameter | Description | Default
 --- | --- | ---
 `discovery.primaryInstancePrefix` | *REQUIRED* Search sting used to find the primary instance ID; is fed to `gcloud sql instances list --filter name:${PRIMARY_INSTANCE_PREFIX}`.  *Must* match only one instance. | (none)
+`discovery.replicaSkipLabel` | If set, replicas that have this GCP instance label set to `"true"` will be excluded from pgpool's backend pool.  This is useful for dedicating specific read replicas to other consumers (e.g. analytics) without pgpool load-balancing application traffic to them. | `""`
 `discovery.pruneThreshold` | Threshold in seconds after which an undiscoverable (missing or not in state `RUNNABLE`) replica will be removed from the generated configuration file. | `900`
 
 <hr>

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,31 @@
 # Upgrading Steps
 
+## `v1.4.1` → `v1.5.0`
+
+### New features
+
+Add the ability to exclude specific CloudSQL read replicas from pgpool's
+backend pool by GCP instance label. This is useful when you have dedicated
+read replicas that serve a specific consumer (e.g. an analytics engine) and
+you don't want pgpool load-balancing general application traffic to them.
+
+To use this feature, apply a GCP label to the CloudSQL instance you want to
+exclude (e.g. `pgpool-cloudsql-skip: "true"`), and set the
+`discovery.replicaSkipLabel` chart value to the label key:
+
+```yaml
+discovery:
+  replicaSkipLabel: "pgpool-cloudsql-skip"
+```
+
+When unset (the default), all replicas of the primary are included as before.
+
+### VALUES - New:
+
+Parameter | Description | Default
+--- | --- | ---
+`discovery.replicaSkipLabel` | If set, replicas with this GCP instance label set to `"true"` are excluded from pgpool's backend pool. | `""`
+
 ## `v1.4.0` → `v1.4.1`
 
 ### SECURITY

--- a/bin/discovery.sh
+++ b/bin/discovery.sh
@@ -110,12 +110,17 @@ while true; do
     done
   fi
 
+  replica_filter="region:${REGION} AND masterInstanceName:${PROJECT_ID}:${primary_name} AND state:RUNNABLE"
+  if [[ -n "${REPLICA_SKIP_LABEL:-}" ]]; then
+    replica_filter+=" AND NOT labels.${REPLICA_SKIP_LABEL}=true"
+  fi
+
   mapfile -t current_replicas < <(
     gcloud \
       --project "${PROJECT_ID}" \
       sql instances list \
       --sort-by serverCaCert.createTime \
-      --filter "region:${REGION} AND masterInstanceName:${PROJECT_ID}:${primary_name} AND state:RUNNABLE" \
+      --filter "${replica_filter}" \
       --format 'csv[no-heading](name,ip_addresses.filter("type:PRIVATE").*extract(ip_address).flatten())'
   )
 

--- a/charts/pgpool-cloudsql/Chart.yaml
+++ b/charts/pgpool-cloudsql/Chart.yaml
@@ -15,7 +15,7 @@ apiVersion: v2
 description: the pgpool-ii connection pooling postgres proxy with automatic discovery of GCP CloudSQL backends
 name: pgpool-cloudsql
 type: application
-version: 1.4.1
+version: 1.5.0
 keywords:
 - postgresql
 - pgpool

--- a/charts/pgpool-cloudsql/templates/deployment.yaml
+++ b/charts/pgpool-cloudsql/templates/deployment.yaml
@@ -102,6 +102,10 @@ spec:
         env:
         - name: PRIMARY_INSTANCE_PREFIX
           value: {{ required "You must set .discovery.primaryInstancePrefix!" .Values.discovery.primaryInstancePrefix | quote }}
+        {{- if .Values.discovery.replicaSkipLabel }}
+        - name: REPLICA_SKIP_LABEL
+          value: {{ .Values.discovery.replicaSkipLabel | quote }}
+        {{- end }}
         - name: STAY_IN_REGION
           value: {{ .Values.discovery.stayInRegion | quote }}
         - name: PRUNE_THRESHOLD

--- a/charts/pgpool-cloudsql/values.yaml
+++ b/charts/pgpool-cloudsql/values.yaml
@@ -108,6 +108,11 @@ discovery:
   # `--filter name:${primaryInstancePrefix}` option and MUST match one and only one
   # non-replica instance.
   primaryInstancePrefix: ""  # REQUIRED!
+  # If set, replicas that have this GCP label set to "true" will be excluded from
+  # pgpool's backend pool.  This is useful for dedicating specific read replicas to
+  # other consumers (e.g. analytics) without pgpool load-balancing application
+  # traffic to them.  The label must be applied to the CloudSQL instance in GCP.
+  replicaSkipLabel: ""
   # The Google Cloud region where discovery logic looks for databases.
   # if "true" it's  the same pod's region,
   # all regions otherwise.


### PR DESCRIPTION
**Summary**

- Adds a new `discovery.replicaSkipLabel` chart option that, when set, excludes CloudSQL replicas with that GCP label set to "true" from pgpool's backend pool
- No behavior change when the option is unset (default)

**Motivation**

pgpool's replica discovery finds all replicas of the primary instance, regardless of their intended purpose. When a dedicated read replica is created for a specific consumer (like an analytics engine that runs long-running queries), pgpool will discover it and load-balance general application traffic to it, defeating the purpose of the isolation.

**Usage**

Label the CloudSQL instance you want to exclude:
```
user_labels = {
  pgpool-cloudsql-skip = "true"
}
```

Then set the chart value:
```
discovery:
  replicaSkipLabel: "pgpool-cloudsql-skip"
```