### PR TITLE
update discovery script to accept multiple skip labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The primary moving parts are:
      - Uses the `gcloud` cli to list any primary dbs that match the `PRIMARY_INSTANCE_PREFIX` env
        variable as a prefix. (i.e. a prefix of `metadata-` matches `metadata-4093504851`)
      - Lists all currently active read replicas of the primary database, excluding any
-       that have a GCP label matching `REPLICA_SKIP_LABEL` set to `true` (see
+       that have any GCP label listed in `REPLICA_SKIP_LABEL` set to `true` (see
        `discovery.replicaSkipLabel`)
      - Uses the [envtpl](https://github.com/subfuzion/envtpl) tool to fill out [pgpool.conf.tmpl](conf/pgpool.conf.tmpl)
        and copy the result into `/etc/pgpool/pgpool.conf` if it differs from what is already there.
@@ -191,7 +191,7 @@ Parameter | Description | Default
 Parameter | Description | Default
 --- | --- | ---
 `discovery.primaryInstancePrefix` | *REQUIRED* Search sting used to find the primary instance ID; is fed to `gcloud sql instances list --filter name:${PRIMARY_INSTANCE_PREFIX}`.  *Must* match only one instance. | (none)
-`discovery.replicaSkipLabel` | If set, replicas that have this GCP instance label set to `"true"` will be excluded from pgpool's backend pool.  This is useful for dedicating specific read replicas to other consumers (e.g. analytics) without pgpool load-balancing application traffic to them. | `""`
+`discovery.replicaSkipLabel` | If set, replicas that have any listed GCP instance label set to `"true"` will be excluded from pgpool's backend pool. Provide either a single label or a comma-separated list. This is useful for dedicating specific read replicas to other consumers (e.g. analytics) without pgpool load-balancing application traffic to them. | `""`
 `discovery.pruneThreshold` | Threshold in seconds after which an undiscoverable (missing or not in state `RUNNABLE`) replica will be removed from the generated configuration file. | `900`
 
 <hr>
@@ -408,4 +408,3 @@ But there was some good news: the
 [pgpool2_exporter](https://github.com/pgpool/pgpool2_exporter) is a standalone
 binary that scrapes and parses the data returned by the "sql-like" commands and
 exports it as a prometheus-compatible `/metrics` endpoint.
-

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ instance no matter what.  This is configureable at deploy time as
 
 Old Version | New Version | Upgrade Guide
 --- | --- | ---
+v1.5.0 | v1.6.0 | [link](UPGRADE.md#v150--v160)
 v1.4.1 | v1.5.0 | [link](UPGRADE.md#v141--v150)
 v1.4.0 | v1.4.1 | [link](UPGRADE.md#v140--v141)
 v1.3.3 | v1.4.0 | [link](UPGRADE.md#v133--v140)
@@ -80,7 +81,7 @@ helm repo update
 ```sh
 export RELEASE_NAME=my-pgpool-service # a name (you will need 1 installed chart for each primary DB)
 export NAMESPACE=my-k8s-namespace     # a kubernetes namespace
-export CHART_VERSION=1.5.0            # a chart version: https://github.com/odenio/pgpool-cloudsql/releases
+export CHART_VERSION=1.6.0            # a chart version: https://github.com/odenio/pgpool-cloudsql/releases
 export VALUES_FILE=./my_values.yaml   # your values file
 
 helm install \

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,15 @@
 # Upgrading Steps
 
+## `v1.5.0` → `v1.6.0`
+
+### New features
+
+The discovery container now accepts multiple skip labels in
+`discovery.replicaSkipLabel` as a comma-separated list. Any replica with one of
+those labels set to `"true"` will be excluded from pgpool's backend pool.
+
+Existing single-label configurations continue to work unchanged.
+
 ## `v1.4.1` → `v1.5.0`
 
 ### New features

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -9,9 +9,10 @@ backend pool by GCP instance label. This is useful when you have dedicated
 read replicas that serve a specific consumer (e.g. an analytics engine) and
 you don't want pgpool load-balancing general application traffic to them.
 
-To use this feature, apply a GCP label to the CloudSQL instance you want to
-exclude (e.g. `pgpool-cloudsql-skip: "true"`), and set the
-`discovery.replicaSkipLabel` chart value to the label key:
+To use this feature, apply one or more GCP labels to the CloudSQL instance you
+want to exclude (e.g. `pgpool-cloudsql-skip: "true"`), and set the
+`discovery.replicaSkipLabel` chart value to the label key or comma-separated
+label keys:
 
 ```yaml
 discovery:
@@ -24,7 +25,7 @@ When unset (the default), all replicas of the primary are included as before.
 
 Parameter | Description | Default
 --- | --- | ---
-`discovery.replicaSkipLabel` | If set, replicas with this GCP instance label set to `"true"` are excluded from pgpool's backend pool. | `""`
+`discovery.replicaSkipLabel` | If set, replicas with any listed GCP instance label set to `"true"` are excluded from pgpool's backend pool. Provide either a single label or a comma-separated list. | `""`
 
 ## `v1.4.0` → `v1.4.1`
 

--- a/bin/discovery.sh
+++ b/bin/discovery.sh
@@ -112,7 +112,14 @@ while true; do
 
   replica_filter="region:${REGION} AND masterInstanceName:${PROJECT_ID}:${primary_name} AND state:RUNNABLE"
   if [[ -n "${REPLICA_SKIP_LABEL:-}" ]]; then
-    replica_filter+=" AND NOT labels.${REPLICA_SKIP_LABEL}=true"
+    IFS=',' read -r -a replica_skip_labels <<<"${REPLICA_SKIP_LABEL}"
+    for replica_skip_label in "${replica_skip_labels[@]}"; do
+      replica_skip_label="${replica_skip_label#"${replica_skip_label%%[![:space:]]*}"}"
+      replica_skip_label="${replica_skip_label%"${replica_skip_label##*[![:space:]]}"}"
+      if [[ -n "${replica_skip_label}" ]]; then
+        replica_filter+=" AND NOT labels.${replica_skip_label}=true"
+      fi
+    done
   fi
 
   mapfile -t current_replicas < <(

--- a/bin/discovery.sh
+++ b/bin/discovery.sh
@@ -112,8 +112,11 @@ while true; do
 
   replica_filter="region:${REGION} AND masterInstanceName:${PROJECT_ID}:${primary_name} AND state:RUNNABLE"
   if [[ -n "${REPLICA_SKIP_LABEL:-}" ]]; then
+    # Support either a single label or a comma-separated list in REPLICA_SKIP_LABEL.
     IFS=',' read -r -a replica_skip_labels <<<"${REPLICA_SKIP_LABEL}"
     for replica_skip_label in "${replica_skip_labels[@]}"; do
+      # Trim surrounding whitespace and ignore empty entries so values like
+      # "foo, bar, ,baz" generate only the intended filter clauses.
       replica_skip_label="${replica_skip_label#"${replica_skip_label%%[![:space:]]*}"}"
       replica_skip_label="${replica_skip_label%"${replica_skip_label##*[![:space:]]}"}"
       if [[ -n "${replica_skip_label}" ]]; then

--- a/charts/pgpool-cloudsql/Chart.yaml
+++ b/charts/pgpool-cloudsql/Chart.yaml
@@ -15,7 +15,7 @@ apiVersion: v2
 description: the pgpool-ii connection pooling postgres proxy with automatic discovery of GCP CloudSQL backends
 name: pgpool-cloudsql
 type: application
-version: 1.5.0
+version: 1.6.0
 keywords:
 - postgresql
 - pgpool

--- a/charts/pgpool-cloudsql/values.yaml
+++ b/charts/pgpool-cloudsql/values.yaml
@@ -108,10 +108,11 @@ discovery:
   # `--filter name:${primaryInstancePrefix}` option and MUST match one and only one
   # non-replica instance.
   primaryInstancePrefix: ""  # REQUIRED!
-  # If set, replicas that have this GCP label set to "true" will be excluded from
-  # pgpool's backend pool.  This is useful for dedicating specific read replicas to
+  # If set, replicas that have any of these GCP labels set to "true" will be
+  # excluded from pgpool's backend pool. Provide either a single label or a
+  # comma-separated list. This is useful for dedicating specific read replicas to
   # other consumers (e.g. analytics) without pgpool load-balancing application
-  # traffic to them.  The label must be applied to the CloudSQL instance in GCP.
+  # traffic to them. The labels must be applied to the CloudSQL instance in GCP.
   replicaSkipLabel: ""
   # The Google Cloud region where discovery logic looks for databases.
   # if "true" it's  the same pod's region,


### PR DESCRIPTION
Updating the discovery script to accept multiple skip labels in REPLICA_SKIP_LABEL as a comma-separated list. Single-label input still works unchanged.