### PR TITLE
v1.6.1: golang and alpine updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG ALPINE_VERSION=3.22
-ARG GO_VERSION=1.25
+ARG ALPINE_VERSION=3.23
+ARG GO_VERSION=1.26.2
 ARG PLATFORM=linux/amd64
 ###
 ### Build PGPool-II from source in a build container
@@ -68,8 +68,6 @@ ARG EXPORTER_VERSION=1.2.2
 RUN git clone -b v${EXPORTER_VERSION} https://github.com/pgpool/pgpool2_exporter
 
 WORKDIR /src/envtpl
-# CVE-2024-45337
-RUN go get golang.org/x/crypto
 RUN go mod tidy
 RUN go install -mod=mod ./cmd/envtpl/...
 
@@ -79,7 +77,7 @@ RUN go install ./cmd/pgpool2_exporter/...
 ###
 ### put together everything in the deploy image
 ###
-FROM --platform=${PLATFORM} alpine:${ALPINE_VERSION}
+FROM --platform=${PLATFORM} alpine:${ALPINE_VERSION} as assemble
 RUN apk update
 RUN apk add --no-cache curl python3
 
@@ -110,6 +108,13 @@ RUN mkdir /etc/templates
 COPY conf/*.conf /etc/templates/
 COPY conf/*.tmpl /etc/templates/
 COPY bin/*.sh /usr/bin/
+
+###
+### smash all layers
+###
+FROM --platform=${PLATFORM} scratch
+
+COPY --from=assemble / /
 
 EXPOSE 5432
 EXPOSE 9898

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ instance no matter what.  This is configureable at deploy time as
 
 Old Version | New Version | Upgrade Guide
 --- | --- | ---
+v1.6.0 | v1.6.1 | [link](UPGRADE.md#v160--v161)
 v1.5.0 | v1.6.0 | [link](UPGRADE.md#v150--v160)
 v1.4.1 | v1.5.0 | [link](UPGRADE.md#v141--v150)
 v1.4.0 | v1.4.1 | [link](UPGRADE.md#v140--v141)
@@ -81,7 +82,7 @@ helm repo update
 ```sh
 export RELEASE_NAME=my-pgpool-service # a name (you will need 1 installed chart for each primary DB)
 export NAMESPACE=my-k8s-namespace     # a kubernetes namespace
-export CHART_VERSION=1.6.0            # a chart version: https://github.com/odenio/pgpool-cloudsql/releases
+export CHART_VERSION=1.6.1            # a chart version: https://github.com/odenio/pgpool-cloudsql/releases
 export VALUES_FILE=./my_values.yaml   # your values file
 
 helm install \

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,12 @@
 # Upgrading Steps
 
+## `v1.6.0` → `v1.6.1`
+
+This is a maintenance release:
+
+* the version of the Go runtime used to build the envtpl package is bumped from 1.25 to 1.26.2
+* the Alpine Linux base image is updated from v3.22 to v3.23
+
 ## `v1.5.0` → `v1.6.0`
 
 ### New features

--- a/charts/pgpool-cloudsql/Chart.yaml
+++ b/charts/pgpool-cloudsql/Chart.yaml
@@ -15,7 +15,7 @@ apiVersion: v2
 description: the pgpool-ii connection pooling postgres proxy with automatic discovery of GCP CloudSQL backends
 name: pgpool-cloudsql
 type: application
-version: 1.6.0
+version: 1.6.1
 keywords:
 - postgresql
 - pgpool


### PR DESCRIPTION
- update the golang runtime to v1.26.2
- remove a golang library patch that is no longer relevant
- update the alpine linux base image to v3.23
- smash all layers in the released docker image